### PR TITLE
Update pubspec.yaml

### DIFF
--- a/lib/downloads_path_provider_28.dart
+++ b/lib/downloads_path_provider_28.dart
@@ -7,8 +7,8 @@ class DownloadsPathProvider {
   static const MethodChannel _channel =
       const MethodChannel('downloads_path_provider_28');
 
-  static Future<Directory> get downloadsDirectory async {
-    final String path = await _channel.invokeMethod('getDownloadsDirectory');
+  static Future<Directory?> get downloadsDirectory async {
+    final String? path = await _channel.invokeMethod('getDownloadsDirectory');
     if (path == null) {
       return null;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ flutter:
   plugin:
     platforms:
       ios:
-        pluginClass: FlutterBlePeripheralPlugin
+        pluginClass: DownloadsPathProviderPlugin
       android:
         package: it.nplace.downloadspathprovider
-        pluginClass: FlutterBlePeripheralPlugin
+        pluginClass: DownloadsPathProviderPlugin

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/chitgoks/downloads_path_provider
 
 environment:
   flutter: ">=1.12.0"
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fixes issue with plugin complaining about not finding master.  

The error is 

The plugin `downloads_path_provider_28` doesn't have a main class defined in

pub-cache/hosted/pub.dartlang.org/downloads_path_provider_28-0.1.1/android/src/main/java/it/nplace/downloadspathprovider/FlutterBlePeripheralPlugin.jav
a or

The fix is naming the plugClass DownloadsPathProviderPlugin as it was before rather than FlutterBlePeripheralPlugin
